### PR TITLE
MNT: Add test subpackage to test ignoring

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     */site-packages/nose/*
     *test*
     metadataStore/__init__.py
+    metadataStore/test/*
 
 exclude_lines =
     def set_default


### PR DESCRIPTION
I think this should take care of coveralls trying to report coverage on the test files
