### PR TITLE
API/DOC: Remove beamline_id; document optional fields with required types

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -234,27 +234,25 @@ def insert(name, doc):
     return _DB_SINGLETON.insert(name, doc)
 
 
-def insert_run_start(time, scan_id, beamline_id, uid, owner='', group='',
-                     project='', **kwargs):
+def insert_run_start(time, uid, **kwargs):
     """Insert a RunStart document into the database.
 
     Parameters
     ----------
     time : float
         The date/time as found at the client side when the run is started
-    scan_id : int
-        Scan identifier visible to the user and data analysis.  This is not
-        a unique identifier.
-    beamline_id : str
-        Beamline String identifier.
     uid : str
         Globally unique id to identify this RunStart
+    scan_id : int, optional
+        Scan identifier visible to the user and data analysis.  This is not
+        a unique identifier.
     owner : str, optional
         A username associated with the RunStart
     group : str, optional
         An experimental group associated with the RunStart
     project : str, optional
         Any project name to help users locate the data
+    sample : str or dict, optional
 
     Returns
     -------
@@ -263,10 +261,7 @@ def insert_run_start(time, scan_id, beamline_id, uid, owner='', group='',
         the full document.
 
     """
-    return _DB_SINGLETON.insert_run_start(time=time, scan_id=scan_id,
-                                          beamline_id=beamline_id, uid=uid,
-                                          owner=owner, group=group,
-                                          project=project, **kwargs)
+    return _DB_SINGLETON.insert_run_start(time=time, uid=uid, **kwargs)
 
 
 def insert_run_stop(run_start, time, uid, exit_status='success', reason='',
@@ -405,8 +400,6 @@ def find_run_starts(**kwargs):
     stop_time : time-like, optional
         timestamp of the latest time that a RunStart was created. See
         docs for `start_time` for examples.
-    beamline_id : str, optional
-        String identifier for a specific beamline
     project : str, optional
         Project name
     owner : str, optional

--- a/metadatastore/core.py
+++ b/metadatastore/core.py
@@ -465,18 +465,27 @@ def get_events_table(descriptor, event_col, descriptor_col,
 # database INSERTION ###################################################
 
 def insert_run_start(run_start_col, run_start_cache,
-                     time, scan_id, beamline_id, uid, **kwargs):
+                     time, uid, **kwargs):
     """Insert a RunStart document into the database.
 
     Parameters
     ----------
     time : float
         The date/time as found at the client side when the run is started
-    scan_id : int
+    uid : str
+        Globally unique id string provided to metadatastore
+    scan_id : int, optional
         Scan identifier visible to the user and data analysis.  This is not
         a unique identifier.
-    beamline_id : str
-        Beamline String identifier.
+    owner : str, optional
+        A username associated with the RunStart
+    group : str, optional
+        An experimental group associated with the RunStart
+    project : str, optional
+        Any project name to help users locate the data
+    sample : str or dict, optional
+    kwargs
+        additional optional or custom fields
 
     Returns
     -------
@@ -493,8 +502,7 @@ def insert_run_start(run_start_col, run_start_cache,
         kwargs.update(custom)
 
     col = run_start_col
-    run_start = dict(time=time, scan_id=scan_id, uid=uid,
-                     beamline_id=beamline_id, **kwargs)
+    run_start = dict(time=time, uid=uid, **kwargs)
 
     col.insert_one(run_start)
 
@@ -554,9 +562,10 @@ def insert_run_stop(run_start_col, run_start_cache,
         raise RuntimeError("Runstop already exits for {!r}".format(run_start))
 
     col = run_stop_col
-    run_stop = dict(run_start=run_start_uid, reason=reason, time=time,
-                    uid=uid,
+    run_stop = dict(run_start=run_start_uid, time=time, uid=uid,
                     exit_status=exit_status, **kwargs)
+    if reason is not None:
+        run_stop['reason'] = reason
 
     col.insert_one(run_stop)
     _cache_run_stop(run_stop, run_stop_cache, run_start_col, run_start_cache)

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -515,7 +515,7 @@ class MDS(MDSRO):
                     'event': 'insert_event',
                     'bulk_events': 'bulk_insert_events'}
 
-    def insert_run_start(self, time, scan_id, beamline_id, uid, **kwargs):
+    def insert_run_start(self, time, uid **kwargs):
         '''Insert a Start document
 
         All extra keyword arguments are passed through to the database
@@ -525,13 +525,20 @@ class MDS(MDSRO):
         ----------
         time : float
             The date/time as found at the client side when the run is started
-        scan_id : int
-            Scan identifier visible to the user and data analysis.  This is not
-            a unique identifier.
-        beamline_id : str
-            Beamline String identifier.
         uid : str
             Globally unique id to identify this RunStart
+        scan_id : int, optional
+            Scan identifier visible to the user and data analysis.  This is not
+            a unique identifier.
+        owner : str, optional
+            A username associated with the RunStart
+        group : str, optional
+            An experimental group associated with the RunStart
+        project : str, optional
+            Any project name to help users locate the data
+        sample : str or dict, optional
+        kwargs
+            passed through
 
         Returns
         -------
@@ -543,8 +550,7 @@ class MDS(MDSRO):
             raise NotImplementedError("Can not create documents of v0 schema")
         return core.insert_run_start(self._runstart_col,
                                      self._RUNSTART_CACHE,
-                                     time, scan_id=scan_id,
-                                     beamline_id=beamline_id,
+                                     time=time, 
                                      uid=uid,
                                      **kwargs)
 


### PR DESCRIPTION
- only uid and time and required
- beamline_id is no longer in the lexicon at all
- owner, group, project, and sample are optional but if present must have the right datatypes
